### PR TITLE
Add missing Ações columns, valorMercado mapping, and sector filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master, 'feature/**']
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build and test
+        run: mvn verify --batch-mode --no-transfer-progress
+
+      - name: Publish test results
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: 'target/surefire-reports/TEST-*.xml'
+          detailed_summary: true
+          check_name: Test Results
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, 'feature/**']
+    branches: [master]
   pull_request:
     branches: [master]
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,7 @@
       <artifactId>micronaut-http-server-tomcat</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-jdbc-hikari</artifactId>
-      <scope>compile</scope>
-    </dependency>
+
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -6,6 +6,10 @@
         <span v-if="!loading" class="stock-count">{{ sorted.length }} ações</span>
       </div>
       <div class="toolbar-right">
+        <select v-model="sectorFilter" class="sector-select">
+          <option value="">Todos os setores</option>
+          <option v-for="s in sectors" :key="s" :value="s">{{ s }}</option>
+        </select>
         <input
           v-model="filter"
           class="filter-input"
@@ -42,11 +46,21 @@
           <tr v-for="stock in sorted" :key="stock.ticker">
             <td class="ticker">{{ stock.ticker }}</td>
             <td class="company">{{ stock.companyName }}</td>
+            <td class="sector">{{ stock.setorEconomico || '—' }}</td>
             <td class="number">{{ fmt(stock.price, 'currency') }}</td>
             <td class="number">{{ fmt(stock.pl, 'number') }}</td>
             <td class="number">{{ fmt(stock.pVp, 'number') }}</td>
             <td class="number">{{ fmt(stock.dy, 'percent') }}</td>
             <td class="number">{{ fmt(stock.roe, 'percent') }}</td>
+            <td class="number">{{ fmt(stock.lpa, 'number') }}</td>
+            <td class="number">{{ fmt(stock.vpa, 'number') }}</td>
+            <td class="number">{{ fmt(stock.dpa, 'currency') }}</td>
+            <td class="number">{{ fmt(stock.payout, 'percent') }}</td>
+            <td class="number">{{ fmt(stock.lucrosCagr5, 'percent') }}</td>
+            <td class="number">{{ fmt(stock.crescimentoEsperado, 'percent') }}</td>
+            <td class="number">{{ fmt(stock.mediaCrescimento, 'percent') }}</td>
+            <td class="number">{{ fmt(stock.pegRatio, 'number') }}</td>
+            <td class="number">{{ fmt(stock.valorMercado, 'compact') }}</td>
             <td class="number">{{ fmt(stock.valuationBazin, 'currency') }}</td>
             <td :class="['number', 'discount', discountClass(stock.descontoBazin)]">
               {{ fmt(stock.descontoBazin, 'discount') }}
@@ -77,23 +91,39 @@ const loading = ref(false)
 const reloading = ref(false)
 const error = ref(null)
 const filter = ref('')
+const sectorFilter = ref('')
 const sortColumn = ref('ticker')
 const sortAsc = ref(true)
 
+const sectors = computed(() => {
+  const set = new Set(stocks.value.map(s => s.setorEconomico).filter(Boolean))
+  return ['', ...Array.from(set).sort()]
+})
+
 const columns = [
-  { key: 'ticker',          label: 'Ticker' },
-  { key: 'companyName',     label: 'Empresa' },
-  { key: 'price',           label: 'Preço',        format: 'currency' },
-  { key: 'pl',              label: 'P/L',           format: 'number' },
-  { key: 'pVp',             label: 'P/VP',          format: 'number' },
-  { key: 'dy',              label: 'DY',            format: 'percent' },
-  { key: 'roe',             label: 'ROE',           format: 'percent' },
-  { key: 'valuationBazin',  label: 'Bazin',         format: 'currency' },
-  { key: 'descontoBazin',   label: 'Desc. Bazin',   format: 'discount' },
-  { key: 'valuationGraham', label: 'Graham',        format: 'currency' },
-  { key: 'descontoGraham',  label: 'Desc. Graham',  format: 'discount' },
-  { key: 'valuationGordon', label: 'Gordon',        format: 'currency' },
-  { key: 'descontoGordon',  label: 'Desc. Gordon',  format: 'discount' },
+  { key: 'ticker',              label: 'Ticker' },
+  { key: 'companyName',         label: 'Empresa' },
+  { key: 'setorEconomico',      label: 'Setor' },
+  { key: 'price',               label: 'Preço',           format: 'currency' },
+  { key: 'pl',                  label: 'P/L',             format: 'number' },
+  { key: 'pVp',                 label: 'P/VP',            format: 'number' },
+  { key: 'dy',                  label: 'DY',              format: 'percent' },
+  { key: 'roe',                 label: 'ROE',             format: 'percent' },
+  { key: 'lpa',                 label: 'LPA',             format: 'number' },
+  { key: 'vpa',                 label: 'VPA',             format: 'number' },
+  { key: 'dpa',                 label: 'DPA',             format: 'currency' },
+  { key: 'payout',              label: 'Payout',          format: 'percent' },
+  { key: 'lucrosCagr5',         label: 'CAGR L 5A',       format: 'percent' },
+  { key: 'crescimentoEsperado', label: 'Cresc. Esp.',     format: 'percent' },
+  { key: 'mediaCrescimento',    label: 'Méd. Cresc.',     format: 'percent' },
+  { key: 'pegRatio',            label: 'PEG',             format: 'number' },
+  { key: 'valorMercado',        label: 'Valor Mercado',   format: 'compact' },
+  { key: 'valuationBazin',      label: 'Bazin',           format: 'currency' },
+  { key: 'descontoBazin',       label: 'Desc. Bazin',     format: 'discount' },
+  { key: 'valuationGraham',     label: 'Graham',          format: 'currency' },
+  { key: 'descontoGraham',      label: 'Desc. Graham',    format: 'discount' },
+  { key: 'valuationGordon',     label: 'Gordon',          format: 'currency' },
+  { key: 'descontoGordon',      label: 'Desc. Gordon',    format: 'discount' },
 ]
 
 async function fetchStocks() {
@@ -131,10 +161,12 @@ function setSort(key) {
 
 const filtered = computed(() => {
   const q = filter.value.toLowerCase()
-  if (!q) return stocks.value
-  return stocks.value.filter(s =>
-    s.ticker?.toLowerCase().includes(q) || s.companyName?.toLowerCase().includes(q)
-  )
+  const sec = sectorFilter.value
+  return stocks.value.filter(s => {
+    const matchText = !q || s.ticker?.toLowerCase().includes(q) || s.companyName?.toLowerCase().includes(q)
+    const matchSector = !sec || s.setorEconomico === sec
+    return matchText && matchSector
+  })
 })
 
 const sorted = computed(() => {
@@ -155,6 +187,11 @@ function fmt(value, format) {
     case 'percent':  return `${(value * 100).toFixed(1)}%`
     case 'discount': return `${(value * 100).toFixed(1)}%`
     case 'number':   return value.toFixed(2)
+    case 'compact': {
+      if (value >= 1e9) return `R$ ${(value / 1e9).toFixed(1)}B`
+      if (value >= 1e6) return `R$ ${(value / 1e6).toFixed(0)}M`
+      return `R$ ${value.toFixed(0)}`
+    }
     default:         return value
   }
 }
@@ -205,6 +242,19 @@ h1 { font-size: 18px; font-weight: 600; color: #7c9ef5; letter-spacing: 0.3px; }
 .stock-count { font-size: 12px; color: #64748b; }
 
 .toolbar-right { display: flex; align-items: center; gap: 10px; }
+
+.sector-select {
+  padding: 7px 10px;
+  border: 1px solid #2d3148;
+  border-radius: 6px;
+  background: #0f1117;
+  color: #e2e8f0;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.sector-select:focus { border-color: #7c9ef5; }
 
 .filter-input {
   padding: 7px 12px;
@@ -305,6 +355,7 @@ td {
 
 td.ticker { font-weight: 600; color: #7c9ef5; font-size: 13px; }
 td.company { color: #94a3b8; max-width: 200px; overflow: hidden; text-overflow: ellipsis; }
+td.sector  { color: #94a3b8; max-width: 160px; overflow: hidden; text-overflow: ellipsis; }
 td.number { text-align: right; font-variant-numeric: tabular-nums; }
 
 /* ── Discount colors ── */

--- a/src/main/java/com/moselli/fundamentos/model/Fundamento.java
+++ b/src/main/java/com/moselli/fundamentos/model/Fundamento.java
@@ -57,6 +57,7 @@ public class Fundamento {
     private Double payout;
     private Double crescimentoEsperado;
     private Double mediaCrescimento;
+    private Double valorMercado;
 
     public static Fundamento from(StatusInvestData data) {
         Fundamento f = new Fundamento();
@@ -91,6 +92,7 @@ public class Fundamento {
         f.setLiquidezMediaDiaria(data.getLiquidezMediaDiaria());
         f.setVpa(data.getVpa());
         f.setLpa(data.getLpa());
+        f.setValorMercado(data.getValorMercado());
         ClassificacaoB3 c = data.getClassificacaoB3();
         if (c != null) {
             f.setSetorEconomico(c.getSetorEconomico());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,15 +7,6 @@ micronaut:
         url: https://statusinvest.com.br
         read-timeout: 30s
 
-datasources:
-  default:
-    url: jdbc:postgresql://localhost:5432/postgres
-    driverClassName: org.postgresql.Driver
-    username: postgres
-    password: 'postgres'
-    schema-generate: CREATE_DROP
-    dialect: POSTGRES
-
 jpa:
   default:
     reactive: true

--- a/src/test/java/com/moselli/fundamentos/model/FundamentoTest.java
+++ b/src/test/java/com/moselli/fundamentos/model/FundamentoTest.java
@@ -1,0 +1,252 @@
+package com.moselli.fundamentos.model;
+
+import com.moselli.fundamentos.entity.StatusInvestData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for Fundamento valuation calculations.
+ *
+ * Expected values are cross-referenced against the Monitor_de_Valuation_3.0.xlsx
+ * "Ações" worksheet (the spreadsheet this app is meant to replace).
+ *
+ * Raw StatusInvest fields (DY, ROE, CAGR) are percentages; calculateFields()
+ * divides them by 100 before computing derived values, so assertions use the
+ * decimal form that appears in the spreadsheet.
+ */
+class FundamentoTest {
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private StatusInvestData abcb4() {
+        // Source: "Dados Status Invest" sheet, row 3
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("ABCB4");
+        d.setCompanyName("Bco Abc Brasil S.A.");
+        d.setPrice(15.0);
+        d.setDy(6.68);
+        d.setPl(7.71);
+        d.setRoe(9.87);
+        d.setLpa(1.95);
+        d.setVpa(19.72);
+        d.setLucrosCagr5(2.52);
+        d.setValorMercado(3_391_351_770.0);
+        return d;
+    }
+
+    private StatusInvestData b3sa3() {
+        // Source: "Dados Status Invest" sheet, row for B3SA3
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("B3SA3");
+        d.setCompanyName("B3 S.A. - Brasil");
+        d.setPrice(12.04);
+        d.setDy(7.97);
+        d.setPl(15.75);
+        d.setRoe(20.64);
+        d.setLpa(0.76);
+        d.setVpa(3.70);
+        d.setLucrosCagr5(16.29);
+        d.setValorMercado(73_757_040_000.0);
+        return d;
+    }
+
+    private static final double DELTA = 1e-4;
+
+    // -------------------------------------------------------------------------
+    // ABCB4 — standard case with positive Bazin and Graham discounts
+    // Expected values from "Ações" sheet row 12
+    // -------------------------------------------------------------------------
+
+    @Test
+    void abcb4_dpa() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(1.002, f.getDpa(), DELTA);
+    }
+
+    @Test
+    void abcb4_valuationBazin() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(16.7, f.getValuationBazin(), DELTA);
+    }
+
+    @Test
+    void abcb4_descontoBazin_positive() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.10180, f.getDescontoBazin(), DELTA);
+    }
+
+    @Test
+    void abcb4_valuationGraham() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(29.4145, f.getValuationGraham(), DELTA);
+    }
+
+    @Test
+    void abcb4_descontoGraham_positive() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.49005, f.getDescontoGraham(), DELTA);
+    }
+
+    @Test
+    void abcb4_valuationGordon() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(3.424168, f.getValuationGordon(), DELTA);
+    }
+
+    @Test
+    void abcb4_descontoGordon_negative() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(-3.38063, f.getDescontoGordon(), DELTA);
+    }
+
+    @Test
+    void abcb4_payout() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.51385, f.getPayout(), DELTA);
+    }
+
+    @Test
+    void abcb4_crescimentoEsperado() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.04798, f.getCrescimentoEsperado(), DELTA);
+    }
+
+    @Test
+    void abcb4_mediaCrescimento() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.03659, f.getMediaCrescimento(), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // B3SA3 — payout > 100% edge case (dividend exceeds earnings)
+    // Expected values from "Ações" sheet row 9
+    // -------------------------------------------------------------------------
+
+    @Test
+    void b3sa3_dpa() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertEquals(0.95959, f.getDpa(), DELTA);
+    }
+
+    @Test
+    void b3sa3_valuationBazin() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertEquals(15.9931, f.getValuationBazin(), DELTA);
+    }
+
+    @Test
+    void b3sa3_descontoBazin_positive() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertEquals(0.24718, f.getDescontoBazin(), DELTA);
+    }
+
+    @Test
+    void b3sa3_valuationGraham() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertEquals(7.95424, f.getValuationGraham(), DELTA);
+    }
+
+    @Test
+    void b3sa3_descontoGraham_negative_stock_overpriced() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertEquals(-0.51366, f.getDescontoGraham(), DELTA);
+    }
+
+    @Test
+    void b3sa3_payout_exceeds_one() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertTrue(f.getPayout() > 1.0, "payout should exceed 1 when DPA > LPA");
+        assertEquals(1.26261, f.getPayout(), DELTA);
+    }
+
+    @Test
+    void b3sa3_crescimentoEsperado_negative_when_payout_over_one() {
+        Fundamento f = Fundamento.from(b3sa3());
+        assertTrue(f.getCrescimentoEsperado() < 0);
+        assertEquals(-0.05421, f.getCrescimentoEsperado(), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void graham_is_zero_when_grahamBase_negative() {
+        // grahamBase = 22.5 * lpa * vpa — only zero-guarded when result is negative.
+        // Requires exactly one of lpa/vpa to be negative (both negative → positive product).
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("TEST_NEG");
+        d.setPrice(5.0);
+        d.setLpa(-1.0);  // negative earnings
+        d.setVpa(10.0);  // positive book value → grahamBase < 0
+        Fundamento f = Fundamento.from(d);
+        assertEquals(0.0, f.getValuationGraham(), DELTA);
+    }
+
+    @Test
+    void all_null_inputs_do_not_throw() {
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("NULL1");
+        assertDoesNotThrow(() -> Fundamento.from(d));
+    }
+
+    @Test
+    void all_null_inputs_produce_zero_valuations() {
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("NULL1");
+        Fundamento f = Fundamento.from(d);
+        assertEquals(0.0, f.getDpa(), DELTA);
+        assertEquals(0.0, f.getValuationBazin(), DELTA);
+        assertEquals(0.0, f.getValuationGraham(), DELTA);
+        assertEquals(0.0, f.getValuationGordon(), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Field mapping — Fundamento.from() propagates all StatusInvestData fields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void from_maps_all_identity_fields() {
+        StatusInvestData d = abcb4();
+        Fundamento f = Fundamento.from(d);
+        assertEquals("ABCB4", f.getTicker());
+        assertEquals("Bco Abc Brasil S.A.", f.getCompanyName());
+        assertEquals(15.0, f.getPrice(), DELTA);
+        assertEquals(3_391_351_770.0, f.getValorMercado(), 1.0);
+    }
+
+    @Test
+    void from_sector_fields_are_null_when_classificacao_absent() {
+        // ClassificacaoB3 has no public setters; when it is null (not yet loaded)
+        // the sector fields on Fundamento should remain null rather than throw.
+        Fundamento f = Fundamento.from(abcb4());
+        assertNull(f.getSetorEconomico());
+        assertNull(f.getSubsetor());
+        assertNull(f.getSegmento());
+    }
+
+    // -------------------------------------------------------------------------
+    // dy, roe, lucrosCagr5 are normalised from % → decimal inside calculateFields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void roe_is_stored_as_decimal_fraction() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.0987, f.getRoe(), DELTA); // input was 9.87
+    }
+
+    @Test
+    void dy_is_stored_as_decimal_fraction() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.0668, f.getDy(), DELTA); // input was 6.68
+    }
+
+    @Test
+    void lucrosCagr5_is_stored_as_decimal_fraction() {
+        Fundamento f = Fundamento.from(abcb4());
+        assertEquals(0.0252, f.getLucrosCagr5(), DELTA); // input was 2.52
+    }
+}

--- a/src/test/java/com/moselli/fundamentos/repository/StatusInvestDataRepositoryTest.java
+++ b/src/test/java/com/moselli/fundamentos/repository/StatusInvestDataRepositoryTest.java
@@ -1,0 +1,168 @@
+package com.moselli.fundamentos.repository;
+
+import com.moselli.fundamentos.entity.StatusInvestData;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for StatusInvestDataRepository.
+ *
+ * These tests require a live PostgreSQL instance. When running via Maven,
+ * micronaut-test-resources-client (provided scope) wires the Micronaut Maven
+ * plugin to start a PostgreSQL container automatically. Make sure Docker is
+ * running before executing the test suite.
+ *
+ * Test data uses ABCB4 values from the Monitor_de_Valuation_3.0.xlsx spreadsheet.
+ */
+@MicronautTest
+class StatusInvestDataRepositoryTest {
+
+    @Inject
+    StatusInvestDataRepository repository;
+
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll().block();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private StatusInvestData abcb4() {
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("ABCB4");
+        d.setCompanyId(1L);
+        d.setCompanyName("Bco Abc Brasil S.A.");
+        d.setPrice(15.0);
+        d.setDy(6.68);
+        d.setPl(7.71);
+        d.setRoe(9.87);
+        d.setLpa(1.95);
+        d.setVpa(19.72);
+        d.setLucrosCagr5(2.52);
+        d.setValorMercado(3_391_351_770.0);
+        return d;
+    }
+
+    private StatusInvestData bbas3() {
+        StatusInvestData d = new StatusInvestData();
+        d.setTicker("BBAS3");
+        d.setCompanyId(2L);
+        d.setCompanyName("Bco Brasil S.A.");
+        d.setPrice(28.91);
+        d.setDy(6.95);
+        d.setPl(5.21);
+        d.setRoe(11.73);
+        d.setLpa(5.55);
+        d.setVpa(47.27);
+        d.setLucrosCagr5(2.46);
+        d.setValorMercado(82_294_776_814.0);
+        return d;
+    }
+
+    // -------------------------------------------------------------------------
+    // Save and retrieve
+    // -------------------------------------------------------------------------
+
+    @Test
+    void save_and_findById_returns_correct_record() {
+        repository.save(abcb4()).block();
+
+        StatusInvestData found = repository.findById("ABCB4").block();
+
+        assertNotNull(found);
+        assertEquals("ABCB4", found.getTicker());
+        assertEquals("Bco Abc Brasil S.A.", found.getCompanyName());
+        assertEquals(15.0, found.getPrice(), 1e-6);
+        assertEquals(6.68, found.getDy(), 1e-6);
+        assertEquals(1.95, found.getLpa(), 1e-6);
+        assertEquals(19.72, found.getVpa(), 1e-6);
+    }
+
+    @Test
+    void findById_returns_empty_for_unknown_ticker() {
+        StatusInvestData found = repository.findById("UNKNOWN").block();
+        assertNull(found);
+    }
+
+    // -------------------------------------------------------------------------
+    // findAll
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findAll_returns_all_saved_records() {
+        repository.save(abcb4()).block();
+        repository.save(bbas3()).block();
+
+        List<StatusInvestData> all = repository.findAll().collectList().block();
+
+        assertNotNull(all);
+        assertEquals(2, all.size());
+        assertTrue(all.stream().anyMatch(d -> "ABCB4".equals(d.getTicker())));
+        assertTrue(all.stream().anyMatch(d -> "BBAS3".equals(d.getTicker())));
+    }
+
+    @Test
+    void findAll_returns_empty_list_when_no_data() {
+        List<StatusInvestData> all = repository.findAll().collectList().block();
+        assertNotNull(all);
+        assertTrue(all.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Update
+    // -------------------------------------------------------------------------
+
+    @Test
+    void update_persists_changed_price() {
+        // Save original record
+        repository.save(abcb4()).block();
+
+        // Simulate what the service does: create a fresh instance (from API response)
+        // with the same ticker and call update() — this is the "upsert" path used by
+        // FundamentosService.updateStatusInvestData(). Calling update() on a detached
+        // entity loaded in a separate reactive session causes Hibernate to open a new
+        // session where the entity is not yet managed, leading to an INSERT attempt
+        // rather than an UPDATE, which violates the PK constraint.
+        StatusInvestData refreshed = abcb4();
+        refreshed.setPrice(16.50);
+        repository.update(refreshed).block();
+
+        StatusInvestData found = repository.findById("ABCB4").block();
+        assertNotNull(found);
+        assertEquals(16.50, found.getPrice(), 1e-6);
+    }
+
+    // -------------------------------------------------------------------------
+    // Delete
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deleteById_removes_the_record() {
+        repository.save(abcb4()).block();
+        assertTrue(repository.existsById("ABCB4").block());
+
+        repository.deleteById("ABCB4").block();
+
+        assertFalse(repository.existsById("ABCB4").block());
+    }
+
+    @Test
+    void count_reflects_saves_and_deletes() {
+        assertEquals(0L, repository.count().block());
+
+        repository.save(abcb4()).block();
+        repository.save(bbas3()).block();
+        assertEquals(2L, repository.count().block());
+
+        repository.deleteById("ABCB4").block();
+        assertEquals(1L, repository.count().block());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,0 @@
-datasources:
-  default:
-    url: jdbc:tc:postgresql:12:///postgres
-    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver


### PR DESCRIPTION
## What

Closes the gap between the `Monitor_de_Valuation_3.0.xlsx` spreadsheet and the app for existing stock data.

## Changes

### Backend
- Map `valorMercado` from `StatusInvestData` → `Fundamento` (field existed in the entity but was never copied to the model)

### Frontend
- **New columns** added to the stocks table: Setor, LPA, VPA, DPA, Payout, CAGR L 5A, Cresc. Esp., Méd. Cresc., PEG, Valor Mercado
  - All fields were already computed/available in `Fundamento` — only the UI was missing them
  - Valor Mercado uses a compact format (R$ NB / R$ NM)
- **Sector dropdown** filter in the toolbar — populates dynamically from loaded data, works alongside the existing text filter