### PR TITLE
Fix StatusInvest data reload: wrapper DTO + field mapping

### DIFF
--- a/src/main/java/com/moselli/fundamentos/client/StatusInvestApiItem.java
+++ b/src/main/java/com/moselli/fundamentos/client/StatusInvestApiItem.java
@@ -1,0 +1,100 @@
+package com.moselli.fundamentos.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Serdeable
+public class StatusInvestApiItem {
+
+    private String ticker;
+
+    @JsonProperty("companyid")
+    private Long companyId;
+
+    @JsonProperty("companyname")
+    private String companyName;
+
+    private Double price;
+
+    private Double dy;
+
+    @JsonProperty("p_l")
+    private Double pl;
+
+    @JsonProperty("p_vp")
+    private Double pVp;
+
+    @JsonProperty("p_ativo")
+    private Double pAtivo;
+
+    @JsonProperty("p_ebit")
+    private Double pEbit;
+
+    @JsonProperty("ev_ebit")
+    private Double evEbit;
+
+    @JsonProperty("margembruta")
+    private Double margemBruta;
+
+    @JsonProperty("margemebit")
+    private Double margemEbit;
+
+    @JsonProperty("margemliquida")
+    private Double margemLiquida;
+
+    @JsonProperty("p_sr")
+    private Double pSr;
+
+    @JsonProperty("p_capitalgiro")
+    private Double pCapitalGiro;
+
+    @JsonProperty("p_ativocirculante")
+    private Double pAtivoCirculante;
+
+    @JsonProperty("giroativos")
+    private Double giroAtivos;
+
+    private Double roe;
+
+    private Double roa;
+
+    private Double roic;
+
+    @JsonProperty("dividaliquidapatrimonioliquido")
+    private Double dividaLiquidaPatrimonioLiquido;
+
+    @JsonProperty("dividaliquidaebit")
+    private Double dividaLiquidaEbit;
+
+    @JsonProperty("pl_ativo")
+    private Double plAtivo;
+
+    @JsonProperty("passivo_ativo")
+    private Double passivoAtivo;
+
+    @JsonProperty("liquidezcorrente")
+    private Double liquidezCorrente;
+
+    @JsonProperty("peg_ratio")
+    private Double pegRatio;
+
+    @JsonProperty("receitas_cagr5")
+    private Double receitasCagr5;
+
+    @JsonProperty("lucros_cagr5")
+    private Double lucrosCagr5;
+
+    @JsonProperty("liquidezmediadiaria")
+    private Double liquidezMediaDiaria;
+
+    private Double vpa;
+
+    private Double lpa;
+
+    @JsonProperty("valormercado")
+    private Double valorMercado;
+}

--- a/src/main/java/com/moselli/fundamentos/client/StatusInvestClient.java
+++ b/src/main/java/com/moselli/fundamentos/client/StatusInvestClient.java
@@ -1,11 +1,10 @@
 package com.moselli.fundamentos.client;
 
 import com.moselli.fundamentos.config.StatusInvestConfig;
-import com.moselli.fundamentos.entity.StatusInvestData;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.http.client.annotation.Client;
-import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import static io.micronaut.http.HttpHeaders.ACCEPT;
 
@@ -14,5 +13,5 @@ import static io.micronaut.http.HttpHeaders.ACCEPT;
 public interface StatusInvestClient {
 
     @Get(StatusInvestConfig.STATUS_INVEST_API_URL_ENDPOINT+StatusInvestConfig.STATUS_INVEST_API_URL_FILTERS)
-    Publisher<StatusInvestData> fetchData();
+    Mono<StatusInvestResponse> fetchData();
 }

--- a/src/main/java/com/moselli/fundamentos/client/StatusInvestResponse.java
+++ b/src/main/java/com/moselli/fundamentos/client/StatusInvestResponse.java
@@ -1,0 +1,17 @@
+package com.moselli.fundamentos.client;
+
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Serdeable
+public class StatusInvestResponse {
+
+    private List<StatusInvestApiItem> list;
+
+    private Integer totalCount;
+}

--- a/src/main/java/com/moselli/fundamentos/entity/StatusInvestData.java
+++ b/src/main/java/com/moselli/fundamentos/entity/StatusInvestData.java
@@ -1,6 +1,5 @@
 package com.moselli.fundamentos.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.annotation.Serdeable;
 import jakarta.persistence.Entity;
@@ -32,19 +31,14 @@ public class StatusInvestData {
 
     private Double dy = 0.0;
 
-    @JsonProperty("p_L")
     private Double pl;
 
-    @JsonProperty("p_VP")
     private Double pVp;
 
-    @JsonProperty("p_Ativo")
     private Double pAtivo;
 
-    @JsonProperty("p_Ebit")
     private Double pEbit;
 
-    @JsonProperty("eV_Ebit")
     private Double evEbit;
 
     private Double margemBruta = 0.0;
@@ -53,13 +47,10 @@ public class StatusInvestData {
 
     private Double margemLiquida = 0.0;
 
-    @JsonProperty("p_SR")
     private Double pSr = 0.0;
 
-    @JsonProperty("p_CapitalGiro")
     private Double pCapitalGiro = 0.0;
 
-    @JsonProperty("p_AtivoCirculante")
     private Double pAtivoCirculante;
 
     private Double giroAtivos;
@@ -70,26 +61,20 @@ public class StatusInvestData {
 
     private Double roic = 0.0;
 
-    @JsonProperty("dividaliquidaPatrimonioLiquido")
     private Double dividaLiquidaPatrimonioLiquido = 0.0;
 
     private Double dividaLiquidaEbit = 0.0;
 
-    @JsonProperty("pl_Ativo")
     private Double plAtivo;
 
-    @JsonProperty("passivo_Ativo")
     private Double passivoAtivo;
 
     private Double liquidezCorrente = 0.0;
 
-    @JsonProperty("peg_Ratio")
     private Double pegRatio = 0.0;
 
-    @JsonProperty("receitas_Cagr5")
     private Double receitasCagr5 = 0.0;
 
-    @JsonProperty("lucros_Cagr5")
     private Double lucrosCagr5 = 0.0;
 
     private Double liquidezMediaDiaria = 0.0;

--- a/src/main/java/com/moselli/fundamentos/service/FundamentosService.java
+++ b/src/main/java/com/moselli/fundamentos/service/FundamentosService.java
@@ -1,5 +1,6 @@
 package com.moselli.fundamentos.service;
 
+import com.moselli.fundamentos.client.StatusInvestApiItem;
 import com.moselli.fundamentos.client.StatusInvestClient;
 import com.moselli.fundamentos.entity.StatusInvestData;
 import com.moselli.fundamentos.repository.StatusInvestDataRepository;
@@ -20,9 +21,10 @@ public class FundamentosService {
     private StatusInvestClient statusInvestClient;
 
     public Mono<Void> updateStatusInvestData() {
-        return Flux.from(statusInvestClient.fetchData())
-                .log()
-                .flatMap(statusInvestDataRepository::update)
+        return statusInvestClient.fetchData()
+                .flatMapMany(response -> Flux.fromIterable(response.getList()))
+                .map(FundamentosService::toEntity)
+                .flatMap(statusInvestDataRepository::save)
                 .doOnError(e -> log.severe("Failed to reload StatusInvest data: " + e.getMessage()))
                 .onErrorResume(e -> Flux.empty())
                 .doOnComplete(() -> log.info("Reload complete"))
@@ -33,4 +35,40 @@ public class FundamentosService {
         return statusInvestDataRepository.findAll();
     }
 
+    private static StatusInvestData toEntity(StatusInvestApiItem item) {
+        StatusInvestData e = new StatusInvestData();
+        e.setTicker(item.getTicker());
+        e.setCompanyId(item.getCompanyId());
+        e.setCompanyName(item.getCompanyName());
+        e.setPrice(item.getPrice());
+        e.setDy(item.getDy() != null ? item.getDy() : 0.0);
+        e.setPl(item.getPl());
+        e.setPVp(item.getPVp());
+        e.setPAtivo(item.getPAtivo());
+        e.setPEbit(item.getPEbit());
+        e.setEvEbit(item.getEvEbit());
+        e.setMargemBruta(item.getMargemBruta() != null ? item.getMargemBruta() : 0.0);
+        e.setMargemEbit(item.getMargemEbit() != null ? item.getMargemEbit() : 0.0);
+        e.setMargemLiquida(item.getMargemLiquida() != null ? item.getMargemLiquida() : 0.0);
+        e.setPSr(item.getPSr() != null ? item.getPSr() : 0.0);
+        e.setPCapitalGiro(item.getPCapitalGiro() != null ? item.getPCapitalGiro() : 0.0);
+        e.setPAtivoCirculante(item.getPAtivoCirculante());
+        e.setGiroAtivos(item.getGiroAtivos());
+        e.setRoe(item.getRoe());
+        e.setRoa(item.getRoa());
+        e.setRoic(item.getRoic() != null ? item.getRoic() : 0.0);
+        e.setDividaLiquidaPatrimonioLiquido(item.getDividaLiquidaPatrimonioLiquido() != null ? item.getDividaLiquidaPatrimonioLiquido() : 0.0);
+        e.setDividaLiquidaEbit(item.getDividaLiquidaEbit() != null ? item.getDividaLiquidaEbit() : 0.0);
+        e.setPlAtivo(item.getPlAtivo());
+        e.setPassivoAtivo(item.getPassivoAtivo());
+        e.setLiquidezCorrente(item.getLiquidezCorrente() != null ? item.getLiquidezCorrente() : 0.0);
+        e.setPegRatio(item.getPegRatio() != null ? item.getPegRatio() : 0.0);
+        e.setReceitasCagr5(item.getReceitasCagr5() != null ? item.getReceitasCagr5() : 0.0);
+        e.setLucrosCagr5(item.getLucrosCagr5() != null ? item.getLucrosCagr5() : 0.0);
+        e.setLiquidezMediaDiaria(item.getLiquidezMediaDiaria() != null ? item.getLiquidezMediaDiaria() : 0.0);
+        e.setVpa(item.getVpa());
+        e.setLpa(item.getLpa());
+        e.setValorMercado(item.getValorMercado());
+        return e;
+    }
 }

--- a/src/test/java/com/moselli/fundamentos/StatusInvestLoadIntegrationTest.java
+++ b/src/test/java/com/moselli/fundamentos/StatusInvestLoadIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.moselli.fundamentos;
+
+import com.moselli.fundamentos.client.StatusInvestApiItem;
+import com.moselli.fundamentos.client.StatusInvestClient;
+import com.moselli.fundamentos.client.StatusInvestResponse;
+import com.moselli.fundamentos.repository.StatusInvestDataRepository;
+import com.moselli.fundamentos.service.FundamentosService;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Calls the real StatusInvest API and persists results to a test database.
+ * Requires internet access and Docker (for the PostgreSQL test container).
+ * Run with: mvn test -Dgroups=external
+ */
+@Tag("external")
+@MicronautTest
+class StatusInvestLoadIntegrationTest {
+
+    @Inject
+    StatusInvestClient statusInvestClient;
+
+    @Inject
+    StatusInvestDataRepository repository;
+
+    @Inject
+    FundamentosService fundamentosService;
+
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll().block();
+    }
+
+    @Test
+    void fetchData_returns_items_with_non_null_tickers() {
+        StatusInvestResponse response = statusInvestClient.fetchData()
+                .block(Duration.ofSeconds(60));
+
+        assertNotNull(response, "fetchData() returned null");
+        assertNotNull(response.getList(), "response.list is null");
+        assertFalse(response.getList().isEmpty(), "StatusInvest API returned an empty list");
+
+        StatusInvestApiItem first = response.getList().get(0);
+        System.out.println("First item ticker: " + first.getTicker());
+        System.out.println("First item companyName: " + first.getCompanyName());
+        System.out.println("First item companyId: " + first.getCompanyId());
+        System.out.println("First item price: " + first.getPrice());
+        System.out.println("First item dy: " + first.getDy());
+        System.out.println("First item pl: " + first.getPl());
+        System.out.println("First item valorMercado: " + first.getValorMercado());
+        System.out.println("Total items received: " + response.getList().size());
+
+        assertNotNull(first.getTicker(), "ticker should not be null after deserialization");
+        assertNotNull(first.getCompanyName(), "companyName should not be null after deserialization");
+    }
+
+    @Test
+    void updateStatusInvestData_persists_records_to_database() {
+        fundamentosService.updateStatusInvestData().block(Duration.ofSeconds(60));
+
+        long count = repository.count().block(Duration.ofSeconds(10));
+        assertTrue(count > 0, "Database should have records after reload");
+        System.out.println("Persisted " + count + " records");
+
+        // Spot-check: first record from the API is retrievable by ticker
+        StatusInvestResponse response = statusInvestClient.fetchData()
+                .block(Duration.ofSeconds(60));
+        assertNotNull(response);
+
+        List<StatusInvestApiItem> items = response.getList();
+        assertFalse(items.isEmpty());
+
+        String firstTicker = items.get(0).getTicker();
+        assertNotNull(firstTicker);
+
+        var found = repository.findById(firstTicker).block();
+        assertNotNull(found, "Record for ticker " + firstTicker + " not found after reload");
+        assertEquals(firstTicker, found.getTicker());
+        assertNotNull(found.getCompanyName(), "companyName should be persisted");
+    }
+}


### PR DESCRIPTION
## Problem

The `/api/reload` endpoint was failing with:

    Identifier of entity 'StatusInvestData' must be manually assigned before calling 'persist()'

Three root causes:

1. **Paginated wrapper**: The API returns `{list:[...], totalCount:N}` but the client was `Publisher<StatusInvestData>`. Micronaut deserializes the wrapper as one entity with all fields null, including `ticker`, causing Hibernate to reject the persist.

2. **Field name mismatch**: All API field names are lowercase (`companyid`, `p_l`, `margembruta`...) while the entity used camelCase with no `@JsonProperty`, so most fields stayed null even after unwrapping.

3. **Micronaut Serde AOT bug**: Adding `@JsonProperty` to any field that did not previously have it on a `@Serdeable` JPA entity causes a null deserializer at runtime.

## Fix

- `StatusInvestResponse` - new wrapper DTO for the paginated envelope
- `StatusInvestApiItem` - new `@Getter @Setter @Serdeable` DTO with all `@JsonProperty` using exact lowercase API field names; no JPA annotations, which avoids the Serde AOT bug
- `StatusInvestData` - reverted to a pure JPA entity, no API mapping annotations
- `StatusInvestClient` - now returns `Mono<StatusInvestResponse>`
- `FundamentosService` - unwraps the list, maps DTO to entity via `toEntity()`, uses `save()` instead of `update()`
- `StatusInvestLoadIntegrationTest` - external integration test (tag=external) that hits the real API and validates end-to-end DB persistence

## Testing

Regular suite (no network):
    mvn test -DexcludedGroups=external

External integration test (requires internet + Docker):
    mvn test -Dgroups=external