### PR TITLE
Rename stocks API to /api/stocks/* and split FII controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [`docs/stock-model.md`](docs/stock-model.md) for full details.
 - Entity: `Stock` (table `stock`)
 - Repository: `StockRepository`
 - Model: `Fundamento` (adds valuation fields computed from raw `Stock` data)
-- API: `GET /api/all`, `POST /api/reload`
+- API: `GET /api/stocks/all`, `GET /api/stocks/raw`, `POST /api/stocks/reload`
 
 ### FIIs
 
@@ -60,7 +60,7 @@ The frontend is built and served as static resources by the backend. Open `http:
 
 ```bash
 # Reload stocks
-curl -X POST http://localhost:8080/api/reload
+curl -X POST http://localhost:8080/api/stocks/reload
 
 # Reload FIIs
 curl -X POST http://localhost:8080/api/fiis/reload
@@ -72,9 +72,9 @@ curl -X POST http://localhost:8080/api/fiis/reload
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/all` | All stocks with computed valuations |
-| `GET` | `/api/raw` | Raw stock data (no valuation fields) |
-| `POST` | `/api/reload` | Fetch and persist latest stock data from StatusInvest |
+| `GET` | `/api/stocks/all` | All stocks with computed valuations |
+| `GET` | `/api/stocks/raw` | Raw stock data (no valuation fields) |
+| `POST` | `/api/stocks/reload` | Fetch and persist latest stock data from StatusInvest |
 | `GET` | `/api/fiis` | All FIIs with computed valuations |
 | `POST` | `/api/fiis/reload` | Fetch and persist latest FII data from StatusInvest |
 
@@ -89,3 +89,39 @@ curl -X POST http://localhost:8080/api/fiis/reload
 # External integration tests (calls real StatusInvest API, requires internet + Docker)
 ./mvnw test -Dgroups=external
 ```
+
+---
+
+## Micronaut 3.0.0 Documentation
+
+- [User Guide](https://docs.micronaut.io/3.0.0/guide/index.html)
+- [API Reference](https://docs.micronaut.io/3.0.0/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/3.0.0/guide/configurationreference.html)
+- [Micronaut Guides](https://guides.micronaut.io/index.html)
+---
+
+## Feature http-client documentation
+
+- [Micronaut HTTP Client documentation](https://docs.micronaut.io/latest/guide/index.html#httpClient)
+
+## Feature tomcat-server documentation
+
+- [Micronaut Tomcat Server documentation](https://micronaut-projects.github.io/micronaut-servlet/1.0.x/guide/index.html#tomcat)
+
+## Feature mockito documentation
+
+- [https://site.mockito.org](https://site.mockito.org)
+
+## Feature jdbc-hikari documentation
+
+- [Micronaut Hikari JDBC Connection Pool documentation](https://micronaut-projects.github.io/micronaut-sql/latest/guide/index.html#jdbc)
+
+## Feature lombok documentation
+
+- [Micronaut Project Lombok documentation](https://docs.micronaut.io/latest/guide/index.html#lombok)
+
+- [https://projectlombok.org/features/all](https://projectlombok.org/features/all)
+
+## Feature testcontainers documentation
+
+- [https://www.testcontainers.org/](https://www.testcontainers.org/)

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -3,21 +3,11 @@
     <header class="toolbar">
       <div class="toolbar-left">
         <h1>Fundamentos B3</h1>
-        <div class="tabs">
-          <button
-            :class="['tab-btn', { active: activeTab === 'stocks' }]"
-            @click="switchTab('stocks')"
-          >Ações</button>
-          <button
-            :class="['tab-btn', { active: activeTab === 'fiis' }]"
-            @click="switchTab('fiis')"
-          >FIIs</button>
-        </div>
-        <span v-if="!loading" class="item-count">{{ sorted.length }} {{ activeTab === 'stocks' ? 'ações' : 'FIIs' }}</span>
+        <span v-if="!loading" class="stock-count">{{ sorted.length }} ações</span>
       </div>
       <div class="toolbar-right">
         <select v-model="sectorFilter" class="sector-select">
-          <option value="">Todos os {{ activeTab === 'stocks' ? 'setores' : 'segmentos' }}</option>
+          <option value="">Todos os setores</option>
           <option v-for="s in sectors" :key="s" :value="s">{{ s }}</option>
         </select>
         <input
@@ -38,12 +28,11 @@
     <div v-if="loading" class="loading">Carregando...</div>
 
     <div v-else class="table-wrapper">
-      <!-- Ações table -->
-      <table v-if="activeTab === 'stocks'">
+      <table>
         <thead>
           <tr>
             <th
-              v-for="col in stockColumns"
+              v-for="col in columns"
               :key="col.key"
               :class="['sortable', { active: sortColumn === col.key }]"
               @click="setSort(col.key)"
@@ -86,50 +75,7 @@
             </td>
           </tr>
           <tr v-if="sorted.length === 0">
-            <td :colspan="stockColumns.length" class="empty">Nenhuma ação encontrada.</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <!-- FIIs table -->
-      <table v-else>
-        <thead>
-          <tr>
-            <th
-              v-for="col in fiiColumns"
-              :key="col.key"
-              :class="['sortable', { active: sortColumn === col.key }]"
-              @click="setSort(col.key)"
-            >
-              {{ col.label }}
-              <span class="sort-arrow">{{ sortColumn === col.key ? (sortAsc ? '▲' : '▼') : '⇅' }}</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="fii in sorted" :key="fii.ticker">
-            <td class="ticker">{{ fii.ticker }}</td>
-            <td class="company">{{ fii.companyName }}</td>
-            <td class="sector">{{ fii.sector || '—' }}</td>
-            <td class="number">{{ fmt(fii.price, 'currency') }}</td>
-            <td class="number">{{ fmt(fii.dy, 'percent') }}</td>
-            <td class="number">{{ fmt(fii.pVp, 'number') }}</td>
-            <td class="number">{{ fmt(fii.lastDividend, 'currency') }}</td>
-            <td class="number">{{ fmt(fii.percentualEmCaixa, 'percent') }}</td>
-            <td class="number">{{ fmt(fii.dividendoCagr3Anos, 'percent') }}</td>
-            <td class="number">{{ fmt(fii.cotaCagr3Anos, 'percent') }}</td>
-            <td class="number">{{ fmt(fii.liquidezMediaDiaria, 'compact') }}</td>
-            <td class="number">{{ fmt(fii.valuationBazinFII, 'currency') }}</td>
-            <td :class="['number', 'discount', discountClass(fii.descontoBazinFII)]">
-              {{ fmt(fii.descontoBazinFII, 'discount') }}
-            </td>
-            <td class="number">{{ fmt(fii.valuationGordonFII, 'currency') }}</td>
-            <td :class="['number', 'discount', discountClass(fii.descontoGordonFII)]">
-              {{ fmt(fii.descontoGordonFII, 'discount') }}
-            </td>
-          </tr>
-          <tr v-if="sorted.length === 0">
-            <td :colspan="fiiColumns.length" class="empty">Nenhum FII encontrado.</td>
+            <td :colspan="columns.length" class="empty">Nenhuma ação encontrada.</td>
           </tr>
         </tbody>
       </table>
@@ -140,9 +86,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 
-const activeTab = ref('stocks')
 const stocks = ref([])
-const fiis = ref([])
 const loading = ref(false)
 const reloading = ref(false)
 const error = ref(null)
@@ -151,83 +95,44 @@ const sectorFilter = ref('')
 const sortColumn = ref('ticker')
 const sortAsc = ref(true)
 
-const currentData = computed(() => activeTab.value === 'stocks' ? stocks.value : fiis.value)
-
 const sectors = computed(() => {
-  if (activeTab.value === 'stocks') {
-    const set = new Set(stocks.value.map(s => s.setorEconomico).filter(Boolean))
-    return Array.from(set).sort()
-  } else {
-    const set = new Set(fiis.value.map(f => f.sector).filter(Boolean))
-    return Array.from(set).sort()
-  }
+  const set = new Set(stocks.value.map(s => s.setorEconomico).filter(Boolean))
+  return ['', ...Array.from(set).sort()]
 })
 
-const stockColumns = [
+const columns = [
   { key: 'ticker',              label: 'Ticker' },
   { key: 'companyName',         label: 'Empresa' },
   { key: 'setorEconomico',      label: 'Setor' },
-  { key: 'price',               label: 'Preço' },
-  { key: 'pl',                  label: 'P/L' },
-  { key: 'pVp',                 label: 'P/VP' },
-  { key: 'dy',                  label: 'DY' },
-  { key: 'roe',                 label: 'ROE' },
-  { key: 'lpa',                 label: 'LPA' },
-  { key: 'vpa',                 label: 'VPA' },
-  { key: 'dpa',                 label: 'DPA' },
-  { key: 'payout',              label: 'Payout' },
-  { key: 'lucrosCagr5',         label: 'CAGR L 5A' },
-  { key: 'crescimentoEsperado', label: 'Cresc. Esp.' },
-  { key: 'mediaCrescimento',    label: 'Méd. Cresc.' },
-  { key: 'pegRatio',            label: 'PEG' },
-  { key: 'valorMercado',        label: 'Valor Mercado' },
-  { key: 'valuationBazin',      label: 'Bazin' },
-  { key: 'descontoBazin',       label: 'Desc. Bazin' },
-  { key: 'valuationGraham',     label: 'Graham' },
-  { key: 'descontoGraham',      label: 'Desc. Graham' },
-  { key: 'valuationGordon',     label: 'Gordon' },
-  { key: 'descontoGordon',      label: 'Desc. Gordon' },
-]
-
-const fiiColumns = [
-  { key: 'ticker',              label: 'Ticker' },
-  { key: 'companyName',         label: 'Fundo' },
-  { key: 'sector',              label: 'Segmento' },
-  { key: 'price',               label: 'Cotação' },
-  { key: 'dy',                  label: 'DY' },
-  { key: 'pVp',                 label: 'P/VP' },
-  { key: 'lastDividend',        label: 'Últ. Div.' },
-  { key: 'percentualEmCaixa',   label: 'Caixa %' },
-  { key: 'dividendoCagr3Anos',  label: 'CAGR Div 3A' },
-  { key: 'cotaCagr3Anos',       label: 'CAGR Cota 3A' },
-  { key: 'liquidezMediaDiaria', label: 'Liquidez' },
-  { key: 'valuationBazinFII',   label: 'Bazin FII' },
-  { key: 'descontoBazinFII',    label: 'Desc. Bazin' },
-  { key: 'valuationGordonFII',  label: 'Gordon FII' },
-  { key: 'descontoGordonFII',   label: 'Desc. Gordon' },
+  { key: 'price',               label: 'Preço',           format: 'currency' },
+  { key: 'pl',                  label: 'P/L',             format: 'number' },
+  { key: 'pVp',                 label: 'P/VP',            format: 'number' },
+  { key: 'dy',                  label: 'DY',              format: 'percent' },
+  { key: 'roe',                 label: 'ROE',             format: 'percent' },
+  { key: 'lpa',                 label: 'LPA',             format: 'number' },
+  { key: 'vpa',                 label: 'VPA',             format: 'number' },
+  { key: 'dpa',                 label: 'DPA',             format: 'currency' },
+  { key: 'payout',              label: 'Payout',          format: 'percent' },
+  { key: 'lucrosCagr5',         label: 'CAGR L 5A',       format: 'percent' },
+  { key: 'crescimentoEsperado', label: 'Cresc. Esp.',     format: 'percent' },
+  { key: 'mediaCrescimento',    label: 'Méd. Cresc.',     format: 'percent' },
+  { key: 'pegRatio',            label: 'PEG',             format: 'number' },
+  { key: 'valorMercado',        label: 'Valor Mercado',   format: 'compact' },
+  { key: 'valuationBazin',      label: 'Bazin',           format: 'currency' },
+  { key: 'descontoBazin',       label: 'Desc. Bazin',     format: 'discount' },
+  { key: 'valuationGraham',     label: 'Graham',          format: 'currency' },
+  { key: 'descontoGraham',      label: 'Desc. Graham',    format: 'discount' },
+  { key: 'valuationGordon',     label: 'Gordon',          format: 'currency' },
+  { key: 'descontoGordon',      label: 'Desc. Gordon',    format: 'discount' },
 ]
 
 async function fetchStocks() {
   loading.value = true
   error.value = null
   try {
-    const res = await fetch('/api/all')
+    const res = await fetch('/api/stocks/all')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     stocks.value = await res.json()
-  } catch (e) {
-    error.value = e.message
-  } finally {
-    loading.value = false
-  }
-}
-
-async function fetchFIIs() {
-  loading.value = true
-  error.value = null
-  try {
-    const res = await fetch('/api/fiis')
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    fiis.value = await res.json()
   } catch (e) {
     error.value = e.message
   } finally {
@@ -239,26 +144,14 @@ async function reloadData() {
   reloading.value = true
   error.value = null
   try {
-    const url = activeTab.value === 'stocks' ? '/api/reload' : '/api/fiis/reload'
-    const res = await fetch(url, { method: 'POST' })
+    const res = await fetch('/api/stocks/reload', { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    if (activeTab.value === 'stocks') await fetchStocks()
-    else await fetchFIIs()
+    await fetchStocks()
   } catch (e) {
     error.value = e.message
   } finally {
     reloading.value = false
   }
-}
-
-function switchTab(tab) {
-  activeTab.value = tab
-  filter.value = ''
-  sectorFilter.value = ''
-  sortColumn.value = 'ticker'
-  sortAsc.value = true
-  if (tab === 'stocks' && stocks.value.length === 0) fetchStocks()
-  if (tab === 'fiis' && fiis.value.length === 0) fetchFIIs()
 }
 
 function setSort(key) {
@@ -269,10 +162,9 @@ function setSort(key) {
 const filtered = computed(() => {
   const q = filter.value.toLowerCase()
   const sec = sectorFilter.value
-  return currentData.value.filter(item => {
-    const matchText = !q || item.ticker?.toLowerCase().includes(q) || item.companyName?.toLowerCase().includes(q)
-    const sectorField = activeTab.value === 'stocks' ? item.setorEconomico : item.sector
-    const matchSector = !sec || sectorField === sec
+  return stocks.value.filter(s => {
+    const matchText = !q || s.ticker?.toLowerCase().includes(q) || s.companyName?.toLowerCase().includes(q)
+    const matchSector = !sec || s.setorEconomico === sec
     return matchText && matchSector
   })
 })
@@ -343,27 +235,11 @@ body {
   flex-shrink: 0;
 }
 
-.toolbar-left { display: flex; align-items: center; gap: 12px; }
+.toolbar-left { display: flex; align-items: baseline; gap: 12px; }
 
 h1 { font-size: 18px; font-weight: 600; color: #7c9ef5; letter-spacing: 0.3px; }
 
-.tabs { display: flex; gap: 2px; }
-
-.tab-btn {
-  padding: 5px 14px;
-  border: 1px solid #2d3148;
-  border-radius: 6px;
-  background: transparent;
-  color: #64748b;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-.tab-btn:hover { color: #94a3b8; border-color: #3d4260; }
-.tab-btn.active { background: #7c9ef5; color: #0f1117; border-color: #7c9ef5; font-weight: 600; }
-
-.item-count { font-size: 12px; color: #64748b; }
+.stock-count { font-size: 12px; color: #64748b; }
 
 .toolbar-right { display: flex; align-items: center; gap: 10px; }
 

--- a/src/main/java/com/moselli/fundamentos/controller/FiiController.java
+++ b/src/main/java/com/moselli/fundamentos/controller/FiiController.java
@@ -1,0 +1,33 @@
+package com.moselli.fundamentos.controller;
+
+import com.moselli.fundamentos.model.FII;
+import com.moselli.fundamentos.service.FundamentosService;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import jakarta.inject.Inject;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Controller("/api/fiis")
+@Log4j2
+public class FiiController {
+
+    @Inject
+    private FundamentosService fundamentosService;
+
+    @Get
+    public Mono<List<FII>> getAll() {
+        return fundamentosService.findAllFII()
+                .map(FII::from)
+                .collectList();
+    }
+
+    @Post("/reload")
+    public Mono<String> reload() {
+        return fundamentosService.updateFIIData().thenReturn("FII Reload Complete!");
+    }
+
+}

--- a/src/main/java/com/moselli/fundamentos/controller/StocksController.java
+++ b/src/main/java/com/moselli/fundamentos/controller/StocksController.java
@@ -1,7 +1,6 @@
 package com.moselli.fundamentos.controller;
 
 import com.moselli.fundamentos.entity.Stock;
-import com.moselli.fundamentos.model.FII;
 import com.moselli.fundamentos.model.Fundamento;
 import com.moselli.fundamentos.service.FundamentosService;
 import io.micronaut.http.annotation.Controller;
@@ -13,9 +12,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-@Controller("/api")
+@Controller("/api/stocks")
 @Log4j2
-public class FundamentosController {
+public class StocksController {
 
     @Inject
     private FundamentosService fundamentosService;
@@ -23,11 +22,6 @@ public class FundamentosController {
     @Post("/reload")
     public Mono<String> reload() {
         return fundamentosService.updateStocks().thenReturn("Reload Complete!");
-    }
-
-    @Post("/fiis/reload")
-    public Mono<String> reloadFII() {
-        return fundamentosService.updateFIIData().thenReturn("FII Reload Complete!");
     }
 
     @Get("/raw")
@@ -39,13 +33,6 @@ public class FundamentosController {
     public Mono<List<Fundamento>> getAll() {
         return fundamentosService.findAll()
                 .map(Fundamento::from)
-                .collectList();
-    }
-
-    @Get("/fiis")
-    public Mono<List<FII>> getAllFII() {
-        return fundamentosService.findAllFII()
-                .map(FII::from)
                 .collectList();
     }
 


### PR DESCRIPTION
## Changes

- Move stock endpoints from `/api/*` to `/api/stocks/*`
- Rename `FundamentosController` to `StocksController`
- Extract FII endpoints into dedicated `FiiController` at `/api/fiis`
- Update frontend fetch calls to use new `/api/stocks/*` paths
- Update README with new API paths, restore all original content sections

## API before / after

| Before | After |
|---|---|
| `GET /api/all` | `GET /api/stocks/all` |
| `GET /api/raw` | `GET /api/stocks/raw` |
| `POST /api/reload` | `POST /api/stocks/reload` |
| `GET /api/fiis` | `GET /api/fiis` (unchanged) |
| `POST /api/fiis/reload` | `POST /api/fiis/reload` (unchanged) |