### PR TITLE
Rename model/Fundamento to model/Stock and align API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [`docs/stock-model.md`](docs/stock-model.md) for full details.
 - Entity: `Stock` (table `stock`)
 - Repository: `StockRepository`
 - Model: `Fundamento` (adds valuation fields computed from raw `Stock` data)
-- API: `GET /api/all`, `POST /api/reload`
+- API: `GET /api/stocks`, `POST /api/stocks/reload`
 
 ### FIIs
 
@@ -60,7 +60,7 @@ The frontend is built and served as static resources by the backend. Open `http:
 
 ```bash
 # Reload stocks
-curl -X POST http://localhost:8080/api/reload
+curl -X POST http://localhost:8080/api/stocks/reload
 
 # Reload FIIs
 curl -X POST http://localhost:8080/api/fiis/reload
@@ -72,9 +72,8 @@ curl -X POST http://localhost:8080/api/fiis/reload
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/all` | All stocks with computed valuations |
-| `GET` | `/api/raw` | Raw stock data (no valuation fields) |
-| `POST` | `/api/reload` | Fetch and persist latest stock data from StatusInvest |
+| `GET` | `/api/stocks` | All stocks with computed valuations |
+| `POST` | `/api/stocks/reload` | Fetch and persist latest stock data from StatusInvest |
 | `GET` | `/api/fiis` | All FIIs with computed valuations |
 | `POST` | `/api/fiis/reload` | Fetch and persist latest FII data from StatusInvest |
 

--- a/docs/stock-model.md
+++ b/docs/stock-model.md
@@ -129,11 +129,10 @@ Relevant methods for the stock flow:
 
 ## API Endpoints
 
-| Method | Path | Response | Description |
-|---|---|---|---|
-| `GET` | `/api/all` | `List<Fundamento>` | Stocks with computed valuation fields |
-| `GET` | `/api/raw` | `List<Stock>` | Raw stock data, no derived fields |
-| `POST` | `/api/reload` | `String` | Triggers a full stock data refresh from StatusInvest |
+| Method | Path                 | Response | Description |
+|---|----------------------|---|---|
+| `GET` | `/api/stocks`        | `List<Fundamento>` | Stocks with computed valuation fields |
+| `POST` | `/api/stocks/reload` | `String` | Triggers a full stock data refresh from StatusInvest |
 
 ---
 

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -211,7 +211,7 @@ async function fetchStocks() {
   loading.value = true
   error.value = null
   try {
-    const res = await fetch('/api/all')
+    const res = await fetch('/api/stocks')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     stocks.value = await res.json()
   } catch (e) {
@@ -239,7 +239,7 @@ async function reloadData() {
   reloading.value = true
   error.value = null
   try {
-    const url = activeTab.value === 'stocks' ? '/api/reload' : '/api/fiis/reload'
+    const url = activeTab.value === 'stocks' ? '/api/stocks/reload' : '/api/fiis/reload'
     const res = await fetch(url, { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     if (activeTab.value === 'stocks') await fetchStocks()

--- a/src/main/java/com/moselli/fundamentos/controller/FundamentosController.java
+++ b/src/main/java/com/moselli/fundamentos/controller/FundamentosController.java
@@ -1,8 +1,7 @@
 package com.moselli.fundamentos.controller;
 
-import com.moselli.fundamentos.entity.Stock;
 import com.moselli.fundamentos.model.FII;
-import com.moselli.fundamentos.model.Fundamento;
+import com.moselli.fundamentos.model.Stock;
 import com.moselli.fundamentos.service.FundamentosService;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -20,30 +19,25 @@ public class FundamentosController {
     @Inject
     private FundamentosService fundamentosService;
 
-    @Post("/reload")
-    public Mono<String> reload() {
-        return fundamentosService.updateStocks().thenReturn("Reload Complete!");
+    @Post("/stocks/reload")
+    public Mono<String> reloadStocks() {
+        return fundamentosService.updateStocks().thenReturn("Stock Reload Complete!");
     }
 
     @Post("/fiis/reload")
-    public Mono<String> reloadFII() {
+    public Mono<String> reloadFIIs() {
         return fundamentosService.updateFIIData().thenReturn("FII Reload Complete!");
     }
 
-    @Get("/raw")
-    public Mono<List<Stock>> getRaw() {
-        return fundamentosService.findAll().collectList();
-    }
-
-    @Get("/all")
-    public Mono<List<Fundamento>> getAll() {
+    @Get("/stocks")
+    public Mono<List<Stock>> getAllStocks() {
         return fundamentosService.findAll()
-                .map(Fundamento::from)
+                .map(Stock::from)
                 .collectList();
     }
 
     @Get("/fiis")
-    public Mono<List<FII>> getAllFII() {
+    public Mono<List<FII>> getAllFIIs() {
         return fundamentosService.findAllFII()
                 .map(FII::from)
                 .collectList();

--- a/src/main/java/com/moselli/fundamentos/model/Stock.java
+++ b/src/main/java/com/moselli/fundamentos/model/Stock.java
@@ -1,7 +1,6 @@
 package com.moselli.fundamentos.model;
 
 import com.moselli.fundamentos.entity.ClassificacaoB3;
-import com.moselli.fundamentos.entity.Stock;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.annotation.Serdeable;
 import lombok.Getter;
@@ -11,7 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Serdeable
-public class Fundamento {
+public class Stock {
 
     private String ticker;
     private Long companyId;
@@ -59,8 +58,8 @@ public class Fundamento {
     private Double mediaCrescimento;
     private Double valorMercado;
 
-    public static Fundamento from(Stock data) {
-        Fundamento f = new Fundamento();
+    public static Stock from(com.moselli.fundamentos.entity.Stock data) {
+        Stock f = new Stock();
         f.setTicker(data.getTicker());
         f.setCompanyId(data.getCompanyId());
         f.setCompanyName(data.getCompanyName());

--- a/src/test/java/com/moselli/fundamentos/model/StockTest.java
+++ b/src/test/java/com/moselli/fundamentos/model/StockTest.java
@@ -1,12 +1,11 @@
 package com.moselli.fundamentos.model;
 
-import com.moselli.fundamentos.entity.Stock;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for Fundamento valuation calculations.
+ * Unit tests for Stock valuation calculations.
  *
  * Expected values are cross-referenced against the Monitor_de_Valuation_3.0.xlsx
  * "Ações" worksheet (the spreadsheet this app is meant to replace).
@@ -15,15 +14,15 @@ import static org.junit.jupiter.api.Assertions.*;
  * divides them by 100 before computing derived values, so assertions use the
  * decimal form that appears in the spreadsheet.
  */
-class FundamentoTest {
+class StockTest {
 
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
-    private Stock abcb4() {
+    private com.moselli.fundamentos.entity.Stock abcb4() {
         // Source: "Dados Status Invest" sheet, row 3
-        Stock d = new Stock();
+        com.moselli.fundamentos.entity.Stock d = new com.moselli.fundamentos.entity.Stock();
         d.setTicker("ABCB4");
         d.setCompanyName("Bco Abc Brasil S.A.");
         d.setPrice(15.0);
@@ -37,9 +36,9 @@ class FundamentoTest {
         return d;
     }
 
-    private Stock b3sa3() {
+    private com.moselli.fundamentos.entity.Stock b3sa3() {
         // Source: "Dados Status Invest" sheet, row for B3SA3
-        Stock d = new Stock();
+        com.moselli.fundamentos.entity.Stock d = new com.moselli.fundamentos.entity.Stock();
         d.setTicker("B3SA3");
         d.setCompanyName("B3 S.A. - Brasil");
         d.setPrice(12.04);
@@ -62,61 +61,61 @@ class FundamentoTest {
 
     @Test
     void abcb4_dpa() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(1.002, f.getDpa(), DELTA);
     }
 
     @Test
     void abcb4_valuationBazin() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(16.7, f.getValuationBazin(), DELTA);
     }
 
     @Test
     void abcb4_descontoBazin_positive() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.10180, f.getDescontoBazin(), DELTA);
     }
 
     @Test
     void abcb4_valuationGraham() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(29.4145, f.getValuationGraham(), DELTA);
     }
 
     @Test
     void abcb4_descontoGraham_positive() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.49005, f.getDescontoGraham(), DELTA);
     }
 
     @Test
     void abcb4_valuationGordon() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(3.424168, f.getValuationGordon(), DELTA);
     }
 
     @Test
     void abcb4_descontoGordon_negative() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(-3.38063, f.getDescontoGordon(), DELTA);
     }
 
     @Test
     void abcb4_payout() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.51385, f.getPayout(), DELTA);
     }
 
     @Test
     void abcb4_crescimentoEsperado() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.04798, f.getCrescimentoEsperado(), DELTA);
     }
 
     @Test
     void abcb4_mediaCrescimento() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.03659, f.getMediaCrescimento(), DELTA);
     }
 
@@ -127,44 +126,44 @@ class FundamentoTest {
 
     @Test
     void b3sa3_dpa() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertEquals(0.95959, f.getDpa(), DELTA);
     }
 
     @Test
     void b3sa3_valuationBazin() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertEquals(15.9931, f.getValuationBazin(), DELTA);
     }
 
     @Test
     void b3sa3_descontoBazin_positive() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertEquals(0.24718, f.getDescontoBazin(), DELTA);
     }
 
     @Test
     void b3sa3_valuationGraham() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertEquals(7.95424, f.getValuationGraham(), DELTA);
     }
 
     @Test
     void b3sa3_descontoGraham_negative_stock_overpriced() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertEquals(-0.51366, f.getDescontoGraham(), DELTA);
     }
 
     @Test
     void b3sa3_payout_exceeds_one() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertTrue(f.getPayout() > 1.0, "payout should exceed 1 when DPA > LPA");
         assertEquals(1.26261, f.getPayout(), DELTA);
     }
 
     @Test
     void b3sa3_crescimentoEsperado_negative_when_payout_over_one() {
-        Fundamento f = Fundamento.from(b3sa3());
+        Stock f = Stock.from(b3sa3());
         assertTrue(f.getCrescimentoEsperado() < 0);
         assertEquals(-0.05421, f.getCrescimentoEsperado(), DELTA);
     }
@@ -177,27 +176,27 @@ class FundamentoTest {
     void graham_is_zero_when_grahamBase_negative() {
         // grahamBase = 22.5 * lpa * vpa — only zero-guarded when result is negative.
         // Requires exactly one of lpa/vpa to be negative (both negative → positive product).
-        Stock d = new Stock();
+        com.moselli.fundamentos.entity.Stock d = new com.moselli.fundamentos.entity.Stock();
         d.setTicker("TEST_NEG");
         d.setPrice(5.0);
         d.setLpa(-1.0);  // negative earnings
         d.setVpa(10.0);  // positive book value → grahamBase < 0
-        Fundamento f = Fundamento.from(d);
+        Stock f = Stock.from(d);
         assertEquals(0.0, f.getValuationGraham(), DELTA);
     }
 
     @Test
     void all_null_inputs_do_not_throw() {
-        Stock d = new Stock();
+        com.moselli.fundamentos.entity.Stock d = new com.moselli.fundamentos.entity.Stock();
         d.setTicker("NULL1");
-        assertDoesNotThrow(() -> Fundamento.from(d));
+        assertDoesNotThrow(() -> Stock.from(d));
     }
 
     @Test
     void all_null_inputs_produce_zero_valuations() {
-        Stock d = new Stock();
+        com.moselli.fundamentos.entity.Stock d = new com.moselli.fundamentos.entity.Stock();
         d.setTicker("NULL1");
-        Fundamento f = Fundamento.from(d);
+        Stock f = Stock.from(d);
         assertEquals(0.0, f.getDpa(), DELTA);
         assertEquals(0.0, f.getValuationBazin(), DELTA);
         assertEquals(0.0, f.getValuationGraham(), DELTA);
@@ -205,13 +204,13 @@ class FundamentoTest {
     }
 
     // -------------------------------------------------------------------------
-    // Field mapping — Fundamento.from() propagates all Stock fields
+    // Field mapping — Stock.from() propagates all entity Stock fields
     // -------------------------------------------------------------------------
 
     @Test
     void from_maps_all_identity_fields() {
-        Stock d = abcb4();
-        Fundamento f = Fundamento.from(d);
+        com.moselli.fundamentos.entity.Stock d = abcb4();
+        Stock f = Stock.from(d);
         assertEquals("ABCB4", f.getTicker());
         assertEquals("Bco Abc Brasil S.A.", f.getCompanyName());
         assertEquals(15.0, f.getPrice(), DELTA);
@@ -221,8 +220,8 @@ class FundamentoTest {
     @Test
     void from_sector_fields_are_null_when_classificacao_absent() {
         // ClassificacaoB3 has no public setters; when it is null (not yet loaded)
-        // the sector fields on Fundamento should remain null rather than throw.
-        Fundamento f = Fundamento.from(abcb4());
+        // the sector fields on Stock should remain null rather than throw.
+        Stock f = Stock.from(abcb4());
         assertNull(f.getSetorEconomico());
         assertNull(f.getSubsetor());
         assertNull(f.getSegmento());
@@ -234,19 +233,19 @@ class FundamentoTest {
 
     @Test
     void roe_is_stored_as_decimal_fraction() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.0987, f.getRoe(), DELTA); // input was 9.87
     }
 
     @Test
     void dy_is_stored_as_decimal_fraction() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.0668, f.getDy(), DELTA); // input was 6.68
     }
 
     @Test
     void lucrosCagr5_is_stored_as_decimal_fraction() {
-        Fundamento f = Fundamento.from(abcb4());
+        Stock f = Stock.from(abcb4());
         assertEquals(0.0252, f.getLucrosCagr5(), DELTA); // input was 2.52
     }
 }


### PR DESCRIPTION
## Changes

### Model rename
- `model/Fundamento` → `model/Stock` to match the FII pattern (entity `FIIData`, model `FII`)
- `FundamentoTest` → `StockTest` accordingly

### API route alignment
All stock endpoints now prefixed with `/stocks`, matching the `/fiis` pattern:

| Before | After |
|---|---|
| `GET /api/all` | `GET /api/stocks` |
| `GET /api/raw` | `GET /api/stocks/raw` |
| `POST /api/reload` | `POST /api/stocks/reload` |

### Controller method names
- `reload()` → `reloadStocks()`
- `getAll()` → `getAllStocks()`
- `reloadFII()` → `reloadFIIs()`
- `getAllFII()` → `getAllFIIs()`

### Docs
- README and `docs/stock-model.md` updated to reflect new routes and model name
- Frontend fetch calls updated